### PR TITLE
Hint module bundlers to ignore node-hid in browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "browserify": "browserify --im -o browser/ledger.js src/index-browserify.js",
     "uglify": "uglifyjs -o browser/ledger.min.js browser/ledger.js",
     "clean": "rm -f browser/ledger.js browser/ledger.min.js"
+  },
+  "browser": {
+    "node-hid": false
   }
 }
 


### PR DESCRIPTION
`node-hid` package depends on a lot of node built-in modules and is not used in rbowser builds.
This change hints module bundlers (like webpack) to cut out this module for browser builds.
https://github.com/defunctzombie/package-browser-field-spec