### PR TITLE
Ensure compilation under node 8 and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Wallet",
     "HW.1",
     "Bitcoin",
-    "Ethereum",    
+    "Ethereum",
     "Hardware Wallet"
   ],
   "author": "Nicolas Bacca",
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/LedgerHQ/ledger-node-js-api",
   "dependencies": {
-	  "node-hid": "0.5.4",
-	  "q": "1.4.1"
+    "node-hid": "0.5.7",
+    "q": "1.4.1"
   },
   "devDependencies": {
     "browserify": "13.1.0",
@@ -40,4 +40,3 @@
     "node-hid": false
   }
 }
-

--- a/test/testBtc.js
+++ b/test/testBtc.js
@@ -21,6 +21,7 @@ function runTest(comm, ledger, timeout) {
         var btc = new ledger.btc(comm);
         return btc.getWalletPublicKey_async("44'/0'/0'/0").then(function (result) {
             console.log(result);
+            comm.close_async()
         })
     })
 

--- a/test/testBtc2.js
+++ b/test/testBtc2.js
@@ -20,9 +20,11 @@ function runTest(comm, ledger, timeout) {
     return comm.create_async(timeout, true).then(function (comm) {
         var btc = new ledger.btc(comm);
         var tx1 = btc.splitTransaction("01000000014ea60aeac5252c14291d428915bd7ccd1bfc4af009f4d4dc57ae597ed0420b71010000008a47304402201f36a12c240dbf9e566bc04321050b1984cd6eaf6caee8f02bb0bfec08e3354b022012ee2aeadcbbfd1e92959f57c15c1c6debb757b798451b104665aa3010569b49014104090b15bde569386734abf2a2b99f9ca6a50656627e77de663ca7325702769986cf26cc9dd7fdea0af432c8e2becc867c932e1b9dd742f2a108997c2252e2bdebffffffff0281b72e00000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88aca0860100000000001976a9144533f5fb9b4817f713c48f0bfe96b9f50c476c9b88ac00000000");
-        return btc.createPaymentTransactionNew_async([[tx1, 1]], ["0'/0/0"], undefined, "01905f0100000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88ac").then(function (result) {
-            console.log(result);
-        })
+        return btc.createPaymentTransactionNew_async([[tx1, 1]], ["0'/0/0"], undefined, "01905f0100000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88ac")
+            .then(function (result) {
+                console.log(result);
+                comm.close_async()
+            })
     })
 
 }

--- a/test/testBtc3.js
+++ b/test/testBtc3.js
@@ -20,9 +20,11 @@ function runTest(comm, ledger, timeout) {
     return comm.create_async(timeout, true).then(function (comm) {
         var btc = new ledger.btc(comm);
         var tx1 = btc.splitTransaction("01000000014ea60aeac5252c14291d428915bd7ccd1bfc4af009f4d4dc57ae597ed0420b71010000008a47304402201f36a12c240dbf9e566bc04321050b1984cd6eaf6caee8f02bb0bfec08e3354b022012ee2aeadcbbfd1e92959f57c15c1c6debb757b798451b104665aa3010569b49014104090b15bde569386734abf2a2b99f9ca6a50656627e77de663ca7325702769986cf26cc9dd7fdea0af432c8e2becc867c932e1b9dd742f2a108997c2252e2bdebffffffff0281b72e00000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88aca0860100000000001976a9144533f5fb9b4817f713c48f0bfe96b9f50c476c9b88ac00000000");
-        return btc.signP2SHTransaction_async([[tx1, 1, "52210289b4a3ad52a919abd2bdd6920d8a6879b1e788c38aa76f0440a6f32a9f1996d02103a3393b1439d1693b063482c04bd40142db97bdf139eedd1b51ffb7070a37eac321030b9a409a1e476b0d5d17b804fcdb81cf30f9b99c6f3ae1178206e08bc500639853ae"]], ["0'/0/0"], "01905f0100000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88ac").then(function (result) {
-            console.log(result);
-        })
+        return btc.signP2SHTransaction_async([[tx1, 1, "52210289b4a3ad52a919abd2bdd6920d8a6879b1e788c38aa76f0440a6f32a9f1996d02103a3393b1439d1693b063482c04bd40142db97bdf139eedd1b51ffb7070a37eac321030b9a409a1e476b0d5d17b804fcdb81cf30f9b99c6f3ae1178206e08bc500639853ae"]], ["0'/0/0"], "01905f0100000000001976a91472a5d75c8d2d0565b656a5232703b167d50d5a2b88ac")
+            .then(function (result) {
+                console.log(result);
+                comm.close_async()
+            })
     })
 }
 

--- a/test/testBtc4.js
+++ b/test/testBtc4.js
@@ -23,6 +23,7 @@ function runTest(comm, ledger, timeout) {
             var v = result['v'] + 27 + 4;
             var signature = Buffer.from(v.toString(16) + result['r'] + result['s'], 'hex').toString('base64');
             console.log("Signature : " + signature);
+            comm.close_async()
         })
     })
 

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -21,6 +21,7 @@ function runTest(comm, ledger, timeout) {
         var eth = new ledger.eth(comm);
         return eth.getAppConfiguration_async().then(function (result) {
             console.log(result);
+            comm.close_async()
         })
     })
 

--- a/test/testEth2.js
+++ b/test/testEth2.js
@@ -21,6 +21,7 @@ function runTest(comm, ledger, timeout) {
         var eth = new ledger.eth(comm);
         return eth.getAddress_async("44'/60'/0'/0'/0").then(function (result) {
             console.log(result);
+            comm.close_async()
         })
     })
 

--- a/test/testEth3.js
+++ b/test/testEth3.js
@@ -19,9 +19,11 @@ function runTest(comm, ledger, timeout) {
 
     return comm.create_async(timeout, true).then(function (comm) {
         var eth = new ledger.eth(comm);
-        eth.signTransaction_async("44'/60'/0'/0'/0", "e8018504e3b292008252089428ee52a8f3d6e5d15f8b131996950d7f296c7952872bd72a2487400080").then(function (result) {
-            console.log(result);
-        })
+        return eth.signTransaction_async("44'/60'/0'/0'/0", "e8018504e3b292008252089428ee52a8f3d6e5d15f8b131996950d7f296c7952872bd72a2487400080")
+            .then(function (result) {
+                console.log(result);
+                comm.close_async()
+            })
     })
 
 }

--- a/test/testEth4.js
+++ b/test/testEth4.js
@@ -26,6 +26,7 @@ function runTest(comm, ledger, timeout) {
                 v = "0" + v;
             }
             console.log("Signature 0x" + result['r'] + result['s'] + v);
+            comm.close_async()
         })
     })
 

--- a/test/tests-node.js
+++ b/test/tests-node.js
@@ -11,7 +11,7 @@ else {
 
 var Q = require('q');
 
-var TIMEOUT = 20;
+var TIMEOUT = 5 * 1000;
 
 var tests = [
     {name: 'testBtc', run: require('./testBtc')},


### PR DESCRIPTION
Bumping node-hid version to [0.5.7](https://github.com/node-hid/node-hid/releases/tag/v0.5.7) ensures compilation under node 8. This version contains pre-build binaries

Fix to tests