### PR TITLE
Upgrades node-hid.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/LedgerHQ/ledger-node-js-api",
   "dependencies": {
-	  "node-hid": "0.5.4",
+	  "node-hid": "0.5.7",
 	  "q": "1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`node-hid 0.5.7` won't install from binaries under `node 8`.  This was fixed in `node-hid 0.5.7`.  I verified locally that _my_ stuff still works fine when `ledgerco` uses `node-hid 0.5.7`, and the author of that library seems to follow semver so I don't think there are any breaking changes.