### PR TITLE
Changed buffer for varints

### DIFF
--- a/src/ledger-btc.js
+++ b/src/ledger-btc.js
@@ -564,7 +564,7 @@ LedgerBtc.prototype.createVarint = function(value) {
 		buffer[2] = ((value >> 8) & 0xff);
 		return buffer;
 	}
-	var buffer = Buffer.alloc(4);
+	var buffer = Buffer.alloc(5);
 	buffer[0] = 0xfe;
 	buffer[1] = (value & 0xff);
 	buffer[2] = ((value >> 8) & 0xff);


### PR DESCRIPTION
If varint is of value bigger than 0xFFFF we need a buffer of size 5 not 4