### PR TITLE
Updates to Node HID 0.6.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/LedgerHQ/ledger-node-js-api",
   "dependencies": {
-    "node-hid": "0.5.7"
+    "node-hid": "0.6.0"
   },
   "devDependencies": {
     "browserify": "13.1.0",


### PR DESCRIPTION
The primary change is addressing https://github.com/node-hid/node-hid/issues/226 which was making it really hard to use CI with Ledger Node JS API.